### PR TITLE
Fixing interrupt generation in samples

### DIFF
--- a/examples/FreeFallDetect/FreeFallDetect.ino
+++ b/examples/FreeFallDetect/FreeFallDetect.ino
@@ -81,7 +81,7 @@ int config_free_fall_detect(void) {
     error += lsm6ds3.writeRegister(LSM6DS3_ACC_GYRO_FREE_FALL, 0x33);
     error += lsm6ds3.writeRegister(LSM6DS3_ACC_GYRO_MD1_CFG, 0x10);
     error += lsm6ds3.writeRegister(LSM6DS3_ACC_GYRO_MD2_CFG, 0x10);
-    error += lsm6ds3.writeRegister(LSM6DS3_ACC_GYRO_TAP_CFG1, 0x01);
+    error += lsm6ds3.writeRegister(LSM6DS3_ACC_GYRO_TAP_CFG1, 0x81);
 
     return error;
 }


### PR DESCRIPTION
The TAP_CFG1 register needs a 0x81 instead of 0x01 
This enables the TIMER_EN bit in the register, triggering the free fall  (interrupts).