### PR TITLE
Add correct definition for CTRL6_C register (preserving backward compatibility)

### DIFF
--- a/LSM6DS3.h
+++ b/LSM6DS3.h
@@ -215,7 +215,8 @@ class LSM6DS3 : public LSM6DS3Core {
 #define LSM6DS3_ACC_GYRO_CTRL3_C  			0X12
 #define LSM6DS3_ACC_GYRO_CTRL4_C  			0X13
 #define LSM6DS3_ACC_GYRO_CTRL5_C  			0X14
-#define LSM6DS3_ACC_GYRO_CTRL6_G  			0X15
+#define LSM6DS3_ACC_GYRO_CTRL6_C  			0X15 // Correct name per datasheet
+#define LSM6DS3_ACC_GYRO_CTRL6_G  			0X15 // Legacy support
 #define LSM6DS3_ACC_GYRO_CTRL7_G  			0X16
 #define LSM6DS3_ACC_GYRO_CTRL8_XL  			0X17
 #define LSM6DS3_ACC_GYRO_CTRL9_XL  			0X18


### PR DESCRIPTION
Problem: The register at address 0x15 is named CTRL6_C in the official LSM6DS3 Datasheet (section 9.17). The library currently defines it as LSM6DS3_ACC_GYRO_CTRL6_G, which is misleading as the _G suffix usually implies Gyro-specific settings, while this register handles common features (like XL High Performance mode).

Solution: I added the correct definition LSM6DS3_ACC_GYRO_CTRL6_C. I kept the old definition LSM6DS3_ACC_GYRO_CTRL6_G to ensure full backward compatibility with existing user sketches.