### PR TITLE
Fix timestamp setup across LSM6DS3 variants

### DIFF
--- a/LSM6DS3.cpp
+++ b/LSM6DS3.cpp
@@ -380,6 +380,9 @@ LSM6DS3::LSM6DS3(uint8_t busType, uint8_t inputArg) : LSM6DS3Core(busType, input
     settings.accelFifoDecimation = 1;  //set 1 for on /1
 
     settings.tempEnabled = 1;
+    settings.timestampEnabled = 0;
+    settings.timestampFifoEnabled = 0;
+    settings.timestampResolution = 0;
 
     //Select interface mode
     settings.commMode = 1;  //Can be modes 1, 2 or 3
@@ -753,7 +756,7 @@ uint32_t LSM6DS3::fifoTimestamp() {
     uint8_t data[6];
     status_t error = readRegisterRegion(data, LSM6DS3_ACC_GYRO_FIFO_DATA_OUT_L, 3*sizeof(uint16_t));
     if (error == IMU_SUCCESS) {
-        return (data[1] << 16) | (data[0] << 8) | data[3];
+        return ((uint32_t)data[2] << 16) | ((uint32_t)data[1] << 8) | (uint32_t)data[0];
     }
     return 0;
 }

--- a/LSM6DS3.cpp
+++ b/LSM6DS3.cpp
@@ -756,7 +756,7 @@ uint32_t LSM6DS3::fifoTimestamp() {
     uint8_t data[6];
     status_t error = readRegisterRegion(data, LSM6DS3_ACC_GYRO_FIFO_DATA_OUT_L, 3*sizeof(uint16_t));
     if (error == IMU_SUCCESS) {
-        return ((uint32_t)data[2] << 16) | ((uint32_t)data[1] << 8) | (uint32_t)data[0];
+        return ((uint32_t)data[1] << 16) | ((uint32_t)data[0] << 8) | (uint32_t)data[3];
     }
     return 0;
 }

--- a/LSM6DS3.cpp
+++ b/LSM6DS3.cpp
@@ -568,11 +568,22 @@ status_t LSM6DS3::begin() {
     }
 
     if (settings.timestampEnabled) {
-        // Enable the timestamp counter (CTRL10_C寄存器)
-        uint8_t ctrl10_c;
-        readRegister(&ctrl10_c, LSM6DS3_ACC_GYRO_CTRL10_C);
-        ctrl10_c |= LSM6DS3_ACC_GYRO_ZEN_G_ENABLED;  // set TIMER_EN
-        writeRegister(LSM6DS3_ACC_GYRO_CTRL10_C, ctrl10_c);
+        // Enable the timestamp counter. TIMER_EN lives at a different
+        // register/bit depending on the die revision (see WHO_AM_I check
+        // above): on the original LSM6DS3 it is TAP_CFG1 bit7, while on
+        // LSM6DS3-C/TR-C that bit position is repurposed and TIMER_EN moved
+        // into CTRL10_C bit5 (which otherwise reads as ZEN_G).
+        if (result == LSM6DS3_ACC_GYRO_WHO_AM_I) { //0x69 LSM6DS3
+            uint8_t tap_cfg1;
+            readRegister(&tap_cfg1, LSM6DS3_ACC_GYRO_TAP_CFG1);
+            tap_cfg1 |= LSM6DS3_ACC_GYRO_TIMER_EN_ENABLED;
+            writeRegister(LSM6DS3_ACC_GYRO_TAP_CFG1, tap_cfg1);
+        } else if (result == LSM6DS3_C_ACC_GYRO_WHO_AM_I) { //0x6A LSM6DS3-C/TR-C
+            uint8_t ctrl10_c;
+            readRegister(&ctrl10_c, LSM6DS3_ACC_GYRO_CTRL10_C);
+            ctrl10_c |= LSM6DS3_ACC_GYRO_ZEN_G_ENABLED;  // set TIMER_EN
+            writeRegister(LSM6DS3_ACC_GYRO_CTRL10_C, ctrl10_c);
+        }
     }
 
     return returnError;


### PR DESCRIPTION
## Problem

The timestamp support added for issue #23 has three related problems:

1. `begin()` always writes bit 5 of `CTRL10_C` when `timestampEnabled` is set. That bit is `TIMER_EN` only on LSM6DS3-C/TR-C (`WHO_AM_I = 0x6A`). On the original LSM6DS3 (`0x69`), bit 5 is `Zen_G`; its timestamp counter is enabled by `TAP_CFG1.TIMER_EN` (bit 7), so the counter never starts.
2. The constructor does not initialize `timestampEnabled`, `timestampFifoEnabled`, or `timestampResolution`. Ordinary non-static instances can therefore use indeterminate timestamp settings.
3. `fifoTimestamp()` shifts promoted `uint8_t` values before converting the result to `uint32_t`. On AVR targets with 16-bit `int`, `data[1] << 16` is undefined and `data[0] << 8` can overflow signed `int`.

The register difference is documented in the official ST datasheets:

- LSM6DS3, DocID026899: `TAP_CFG` (58h) bit 7 is `TIMER_EN`; `CTRL10_C` bit 5 is `Zen_G`.
- LSM6DS3TR-C, DocID030071: `CTRL10_C` (19h) bit 5 is `TIMER_EN`; `TAP_CFG` bit 7 is `INTERRUPTS_ENABLE`.

## Fix

- Select the timestamp enable register from the existing `WHO_AM_I` result: `TAP_CFG1` for `0x69`, `CTRL10_C` for `0x6A`.
- Initialize all timestamp settings to zero in the constructor.
- Preserve the documented fourth-dataset byte indexes while casting each byte to `uint32_t` before shifting, making the expression valid on AVR targets with 16-bit `int`.

## Testing

Compiled the real `LSM6DS3.cpp` with a host-side I2C register stub using:

```text
g++ -std=c++11 -Wall -Wextra -Werror
```

The same tests were run against `origin/master` and this branch:

| Case | `origin/master` | Fixed |
|---|---|---|
| Timestamp settings after construction over `0xA5`-filled storage | Fail | Pass, all zero |
| Enable timestamp on LSM6DS3 (`0x69`) | Fail, `TAP_CFG1` remains `0x05` | Pass, becomes `0x85` |
| Enable timestamp on LSM6DS3-C/TR-C (`0x6A`) | Pass | Pass, unchanged behavior |
| Decode FIFO bytes `56 34 12 A5` | `0x3456A5` | `0x3456A5`, layout unchanged |
